### PR TITLE
Task added debug type to mountains

### DIFF
--- a/stepzen/schema/mountains.graphql
+++ b/stepzen/schema/mountains.graphql
@@ -3,8 +3,21 @@ type Mountain {
 }
 
 type Query {
-  mountains: [Mountain]
-    @rest(
-      endpoint:"https://api.nuxtjs.dev/mountains"
-    )
+  mountains: [Mountain] @rest(endpoint: "https://api.nuxtjs.dev/mountains")
+}
+
+type debug {
+  args: JSON
+  data: JSON
+  files: JSON
+  form: JSON
+  headers: JSON
+  json: JSON
+  method: String
+  url: String
+}
+
+type Query {
+  debugger(id: String!): debug
+    @rest(endpoint: "https://httpbin.org/anything/$id")
 }


### PR DESCRIPTION
# Linked Issue
https://github.com/stepzen-samples/stepzen-nuxt/issues/5

# Description
This PR adds a debugger to `mountains.graphql` and has httpbin.org format the response.

# Methodology
Adding this query to the schema is helpful for when things go wrong. The response from the `mountains.graphql` request endpoint returns from httpbin.org in a visible way. It helps see the information in your request is formatted properly